### PR TITLE
GitHub integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,102 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+
+## How To Run
+
+
+1. Setup PostgresSQL
+
+`PostgreSQL` should be installed and running, with the database and user setup. For example, in `config/database.yml`:
+
+```
+development:
+  adapter: postgresql
+  encoding: unicode
+  database: bookstore_dev
+  pool: 5
+  username: alvin
+  password: paywith
+  timeout: 5000
+```
+Edit this file and specify `database`, `username`, `password` that matches what is on your system. We are expecting the default port `5432` to be used.
+
+
+2. Run rails server
+
+Run `bin/rails s` in the root directory of this project
+
+3. Run ember client
+
+Run `ember server --proxy http://localhost:3000` in the `bookstore` subdirectory
+
+4. Open browser client
+
+Go to `http://localhost:4200` in the browser.  The details in the UI are outlined in the tutorial.  In summary, the root page shows list of books, click 'Show More' to view full more books.  Clicking on any book will show the modal purchase dialog.  Clicking on an author will redirect to the author page with their published books.
+
+
+## Creating Authors Using Github Issues
+
+1. Go to the issues page of this repo (https://github.com/alvinlau/bookstore/issues) and create new issues via `New Issue` button
+
+2. Enter the author name as the title of the issue, and the author bio in the description (initial comment) of the issue.
+
+## Fetch changes to authors
+
+At any point in time, the rake task can be run to fetch new changes to authors on Github Issues
+
+`bin/rake authors:refresh`
+ 
+This will detect new authors and any modifications and update them in the database.
+
+## Modifying Authors
+
+Similar to creating authors, existing authors created on Github Issues can be changed by editing the issue title and/or description (initial comment).  Run the rake task again to import the change.
+
+## Deleting Authors
+
+Deleting authors on Github Issues and then running the rake task will also result in the authors being deleted in the database.
+
+
+
+# How it works
+
+In our rake task `authors:refresh`, we call the Github Issues API using the `github_api`.  Using the API we make calls to get list of issues and issue events, after a certain `since` timestamp.  We process the issues and events and make relevant changes in our database, and if everything completes to the end, we store the timestamp in the `Settings` table in the `github_update` entry.  This timestamp marks the point in time where every issue and event before it has been processed and added to your database, so the next call can use this timestamp as the `since` parameter to the Github Issues API.
+
+This process is idempotent, if something fails during part of the rake task and does not reach the end, the `github_update` timestamp in our database simply does not get updated.  In this case when the rake task gets run again, some of the issues and events we processed before the failure would be processed again but they will not have duplicate effects (including create, update, delete).  Only when all the issues and events are succesfully processed then we update the `github_update` timestamp.
+
+For each author in our database, we added the field `github_issue_num` to tracks which issue on Github the author is fetched from.  It is unique, starts at 1 for a new repo, so I picked it over Github Issue Id which is a long number.  In this situation, The Github Issues list becomes the source of truth, and entries our `Authors` are here to reflect that.
+
+## Github issues response behavior
+
+During development and testing of this feature, we found that the call to get issues will return ONE issue response for each of these things that happens to an issue:
+- New issue is opened
+- Issue is renamed (title change)
+- Issue description changed (edit or add comment)
+- Issue is reopened (previously closed)
+
+This heavily influenced the way the rake task is written and is the justification for all of the actions.
+
+## Github issue events response behavior
+
+Similar to the call to get issues, the call to get issue events also takes a `since` timestamp.  Unfortunately, events are only returned for issue `closed` events, but not for new issues and issue description (comment) changes.  We still rely on it to prcoess `renamed` (author name change) events.
+
+## Additional changes and details
+
+- I made the `Bio` section not display on the author page if the author has no bio
+- Github Issues API also return pull requests as issues, and they are denoted as such by having the `pull_request` field.  I simply filter the issues containing the `pull_request` field so we only look at real issues
+- Since an author has one (created automatically as per requirement) or more books, when we delete an author through the rake task, we also cascade delete books associated with the author as well.  As future work we could create a `No author` author and assign the orphaned books to that dummy user, if we want to preserve the books data
+- Time format: Github takes time format in `iso8601` format, e.g. `2020-09-28T07:22:29Z`.  It is why I used expressions like `0.days.ago.iso8601` in the code instead of `Time.now` because it gives time values like `2020-09-28 07:22:29.120376` which Github outright rejects
+
+## Further Improvements
+
+- Making use the `since` and `state: closed` params, we could process delete authors without using issue events, but that is still risky in case no event is generated or if it is not marked with the closed time from Github, since we need it to happen after our previous update timestamp
+- Since issues that have been renamed also show up in list of updated issues, we could just use that instead of using the `renamed` event
+- Use webhooks! https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks.  It seems some of the events we are looking for, are generated if we use webhooks.  To use it we will need to make another POST endpoint that Github will call.  We also need to register our host address on Github.  We could put it up on Heroku or Digital Ocean and paste the public IP each time we run the app, in order to demo it.
+- Write tests but we would have to move the code to actual class/controllers in the app, in order to mock/instantiate them for testing.
+
+
+# Tutorial Notes
+
 
 Things that are changed or different from the tutorial sample code:
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Similar to the call to get issues, the call to get issue events also takes a `si
 
 - Making use the `since` and `state: closed` params, we could process delete authors without using issue events, but that is still risky in case no event is generated or if it is not marked with the closed time from Github, since we need it to happen after our previous update timestamp
 - Since issues that have been renamed also show up in list of updated issues, we could just use that instead of using the `renamed` event
+- Authentication: add config to specific authenticating as Github user used in the Github API calls, right now the unauthenticated calls is rate limited to 60 requests per hour.  Here is the doc that describes it https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting
+  ```
+  For unauthenticated requests, the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the user making requests.
+  ```
 - Use webhooks! https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks.  It seems some of the events we are looking for, are generated if we use webhooks.  To use it we will need to make another POST endpoint that Github will call.  We also need to register our host address on Github.  We could put it up on Heroku or Digital Ocean and paste the public IP each time we run the app, in order to demo it.
 - Write tests but we would have to move the code to actual class/controllers in the app, in order to mock/instantiate them for testing.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,3 @@
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
 require_relative 'config/application'
 require 'github_api'
 
@@ -11,25 +8,39 @@ namespace :authors do
     last_update_time = Setting.where(name: 'github_update').first.value
     puts "get github issues and events since #{last_update_time}"
     issues_api = Github::Client::Issues.new
-    issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: last_update_time
-    events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: last_update_time
+    issues = issues_api.list(user: 'alvinlau', repo: 'bookstore', state: 'open', since: last_update_time)
+    events = issues_api.events.list(user: 'alvinlau', repo: 'bookstore', since: last_update_time)
     puts issues.size.to_s + ' issues'
     puts events.size.to_s + ' events'
 
     issues.each do |issue|
-      authors_found = Author.where(github_issue_id: issue.id)
+      puts 'issue ' + issue.number.to_s
+      authors_found = Author.where(github_issue_num: issue.number)
       if authors_found.empty?
-        puts "create author #{issue.title} - #{issue.id}"
-        Author.create(name: issue.title, bio: issue.body, github_issue_id: issue.id)
-      else
-        puts "update author #{issue.title} - #{issue.id}"
-        authors_found.first.update(bio: issue.body)
+        puts "create author #{issue.title} - #{issue.number}"
+        Author.create(name: issue.title, bio: issue.body, github_issue_num: issue.number)
+      end
+      
+      comments = issues_api.comments.list(
+        user: 'alvinlau', 
+        repo: 'bookstore', 
+        number: issue.number, 
+        since: last_update_time
+      )
+      unless comments.empty?
+        puts "update author #{issue.title} - #{issue.number}"
+        last_comment = comments.to_a.last.body
+        authors_found.first.update(bio: last_comment)
       end
     end
 
-    closed_github_issue_ids = events.filter{|e| e.event == 'closed'}.map{|e| e.issue.id}
-    Author.where(github_issue_id: closed_github_issue_ids).destroy_all
+    closed_events = events.filter{|e| e.event == 'closed'}
+    closed_github_issue_nums = closed_events.map{|e| e.issue.number}
+    Author.where(github_issue_num: closed_github_issue_nums).destroy_all
+    closed_events.each{|e| puts "delete author #{e.issue.title}"}
 
-    Setting.where(name: 'github_update').first.update(value: 0.days.ago.iso8601)
+    new_timestamp = 0.days.ago.iso8601
+    Setting.where(name: 'github_update').first.update(value: new_timestamp)
+    puts "completed refresh author from github issues at #{new_timestamp}"
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -9,29 +9,25 @@ Rails.application.load_tasks
 namespace :authors do
   task :refresh do
     last_update_time = Setting.where(name: 'github_update').first.value
+    puts "get github issues and events since #{last_update_time}"
     issues_api = Github::Client::Issues.new
-    issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: 3.day.ago.iso8601
-    # events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
-    # issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: last_update_time
+    issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: last_update_time
     events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: last_update_time
+    puts issues.size.to_s + ' issues'
+    puts events.size.to_s + ' events'
 
     issues.each do |issue|
       authors_found = Author.where(github_issue_id: issue.id)
       if authors_found.empty?
         puts "create author #{issue.title} - #{issue.id}"
-        Author.create(name: issue.title, github_issue_id: issue.id)
+        Author.create(name: issue.title, bio: issue.body, github_issue_id: issue.id)
       else
         puts "update author #{issue.title} - #{issue.id}"
-        # comments = 
-        # authors_found.first.update()
+        authors_found.first.update(bio: issue.body)
       end
     end
 
-
-    puts 'closed issues'
-    closed_github_issue_ids = events.filter{|e| e.event == 'closed'}
-                                    .map{|e| e.issue.id}
-    puts closed_github_issue_ids
+    closed_github_issue_ids = events.filter{|e| e.event == 'closed'}.map{|e| e.issue.id}
     Author.where(github_issue_id: closed_github_issue_ids).destroy_all
 
     Setting.where(name: 'github_update').first.update(value: 0.days.ago.iso8601)

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,8 @@ namespace :authors do
       end
     end
 
-    issues.each do |issue|
+    # filter out pull requests
+    issues.select{|i| i.pull_request.nil?}.each do |issue|
       puts 'issue ' + issue.number.to_s
       authors_found = Author.where(github_issue_num: issue.number)
       if authors_found.empty?
@@ -31,19 +32,10 @@ namespace :authors do
         Author.create(name: issue.title, bio: issue.body, github_issue_num: issue.number)
         puts 'done'
       end
-      
-      comments = issues_api.comments.list(
-        user: 'alvinlau', 
-        repo: 'bookstore', 
-        number: issue.number, 
-        since: last_update_time
-      )
-      unless comments.empty?
-        print "update bio for author #{issue.title} - #{issue.number} ... "
-        last_comment = comments.to_a.last.body
-        authors_found.first.update(bio: last_comment)
-        puts 'done'
-      end
+
+      print "update bio for author #{issue.title} - #{issue.number} ... "
+      authors_found.first.update(bio: issue.body)
+      puts 'done'
     end
 
     closed_events = events.filter{|e| e.event == 'closed' && e.created_at > last_update_time}

--- a/Rakefile
+++ b/Rakefile
@@ -8,18 +8,32 @@ Rails.application.load_tasks
 
 namespace :authors do
   task :refresh do
+    last_update_time = Setting.where(name: 'github_update').first.value
     issues_api = Github::Client::Issues.new
-    # puts 1.day.ago.iso8601
-    issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
-    events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
+    issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: 3.day.ago.iso8601
+    # events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
+    # issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: last_update_time
+    events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: last_update_time
 
-    # issues.map {|i| pp i}
+    issues.each do |issue|
+      authors_found = Author.where(github_issue_id: issue.id)
+      if authors_found.empty?
+        puts "create author #{issue.title} - #{issue.id}"
+        Author.create(name: issue.title, github_issue_id: issue.id)
+      else
+        puts "update author #{issue.title} - #{issue.id}"
+        # comments = 
+        # authors_found.first.update()
+      end
+    end
+
+
     puts 'closed issues'
-    closed_github_issue_ids = events.filter{|e| e.event == 'closed'}.map{|e| e.issue.id}
+    closed_github_issue_ids = events.filter{|e| e.event == 'closed'}
+                                    .map{|e| e.issue.id}
     puts closed_github_issue_ids
     Author.where(github_issue_id: closed_github_issue_ids).destroy_all
 
-    # Author.create(name: "Clark Kent")
     Setting.where(name: 'github_update').first.update(value: 0.days.ago.iso8601)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,20 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
+require 'github_api'
 
 Rails.application.load_tasks
+
+namespace :authors do
+  task :refresh do
+    issues_api = Github::Client::Issues.new
+    puts 1.day.ago.iso8601
+    issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
+    # events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
+
+    issues.map {|i| pp i}
+    # events.map {|e| pp e}
+
+    # Author.create(name: "Clark Kent")
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -17,5 +17,6 @@ namespace :authors do
     # events.map {|e| pp e}
 
     # Author.create(name: "Clark Kent")
+    Setting.where(name: 'github_update').first.update(value: 0.days.ago.iso8601)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ namespace :authors do
       if authors_found.empty?
         print "create author #{issue.title} - #{issue.number} ... "
         author = Author.create(name: issue.title, bio: issue.body, github_issue_num: issue.number)
-        author.books.create(title: "Self Published Title", price: 9.99, author: author, publisher: author)
+        author.books.create(title: 'First Book From ' + issue.title, price: 9.99, author: author, publisher: author)
         puts 'done'
       end
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,12 +13,23 @@ namespace :authors do
     puts issues.size.to_s + ' issues'
     puts events.size.to_s + ' events'
 
+    renamed_events = events.filter{|e| e.event == 'renamed' && e.created_at > last_update_time}
+    unless renamed_events.empty?
+      renamed_events.each do |e| 
+        author = Author.where(github_issue_num: e.issue.number).first
+        print "rename author #{author.name} to #{e.issue.title} ... "  
+        author.update(name: e.issue.title)
+        puts 'done'
+      end
+    end
+
     issues.each do |issue|
       puts 'issue ' + issue.number.to_s
       authors_found = Author.where(github_issue_num: issue.number)
       if authors_found.empty?
-        puts "create author #{issue.title} - #{issue.number}"
+        print "create author #{issue.title} - #{issue.number} ... "
         Author.create(name: issue.title, bio: issue.body, github_issue_num: issue.number)
+        puts 'done'
       end
       
       comments = issues_api.comments.list(
@@ -28,16 +39,20 @@ namespace :authors do
         since: last_update_time
       )
       unless comments.empty?
-        puts "update author #{issue.title} - #{issue.number}"
+        print "update bio for author #{issue.title} - #{issue.number} ... "
         last_comment = comments.to_a.last.body
         authors_found.first.update(bio: last_comment)
+        puts 'done'
       end
     end
 
-    closed_events = events.filter{|e| e.event == 'closed'}
-    closed_github_issue_nums = closed_events.map{|e| e.issue.number}
-    Author.where(github_issue_num: closed_github_issue_nums).destroy_all
-    closed_events.each{|e| puts "delete author #{e.issue.title}"}
+    closed_events = events.filter{|e| e.event == 'closed' && e.created_at > last_update_time}
+    unless closed_events.empty?
+      closed_github_issue_nums = closed_events.map{|e| e.issue.number}
+      closed_events.each{|e| puts "delete author #{e.issue.title}"}
+      Author.where(github_issue_num: closed_github_issue_nums).destroy_all
+      puts 'done deleting authors'
+    end
 
     new_timestamp = 0.days.ago.iso8601
     Setting.where(name: 'github_update').first.update(value: new_timestamp)

--- a/Rakefile
+++ b/Rakefile
@@ -9,12 +9,15 @@ Rails.application.load_tasks
 namespace :authors do
   task :refresh do
     issues_api = Github::Client::Issues.new
-    puts 1.day.ago.iso8601
+    # puts 1.day.ago.iso8601
     issues = issues_api.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
-    # events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
+    events = issues_api.events.list user: 'alvinlau', repo: 'bookstore', since: 1.day.ago.iso8601
 
-    issues.map {|i| pp i}
-    # events.map {|e| pp e}
+    # issues.map {|i| pp i}
+    puts 'closed issues'
+    closed_github_issue_ids = events.filter{|e| e.event == 'closed'}.map{|e| e.issue.id}
+    puts closed_github_issue_ids
+    Author.where(github_issue_id: closed_github_issue_ids).destroy_all
 
     # Author.create(name: "Clark Kent")
     Setting.where(name: 'github_update').first.update(value: 0.days.ago.iso8601)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,2 @@
+class Setting < ApplicationRecord
+end

--- a/app/serializers/author_serializer.rb
+++ b/app/serializers/author_serializer.rb
@@ -1,5 +1,5 @@
 class AuthorSerializer < ActiveModel::Serializer
-  attributes :id, :name, :discount
+  attributes :id, :name, :bio, :discount
   has_many :books
   has_many :published
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ development:
   database: bookstore_dev
   pool: 5
   username: alvin
-  password: 
+  password: paywith
   timeout: 5000
  
   # Connect on a TCP socket. Omitted by default since the client uses a

--- a/db/migrate/20200925000000_create_settings.rb
+++ b/db/migrate/20200925000000_create_settings.rb
@@ -1,0 +1,10 @@
+class CreateSettings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :settings do |t|
+      t.string :name
+      t.string :type
+      t.string :value
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200925000000_create_settings.rb
+++ b/db/migrate/20200925000000_create_settings.rb
@@ -2,7 +2,6 @@ class CreateSettings < ActiveRecord::Migration[5.2]
   def change
     create_table :settings do |t|
       t.string :name
-      t.string :type
       t.string :value
       t.timestamps
     end

--- a/db/migrate/20200925000001_modify_authors_add_github_issue_id.rb
+++ b/db/migrate/20200925000001_modify_authors_add_github_issue_id.rb
@@ -1,0 +1,5 @@
+class ModifyAuthorsAddGithubIssueId < ActiveRecord::Migration[5.2]
+  def change
+    add_column :authors, :github_issue_id, :integer
+  end
+end

--- a/db/migrate/20200926000000_modify_authors_add_bio.rb
+++ b/db/migrate/20200926000000_modify_authors_add_bio.rb
@@ -1,0 +1,5 @@
+class ModifyAuthorsAddBio < ActiveRecord::Migration[5.2]
+  def change
+    add_column :authors, :bio, :text
+  end
+end

--- a/db/migrate/20200926000001_modify_authors_github_issue_id_to_number.rb
+++ b/db/migrate/20200926000001_modify_authors_github_issue_id_to_number.rb
@@ -1,0 +1,6 @@
+class ModifyAuthorsGithubIssueIdToNumber < ActiveRecord::Migration[5.2]
+  def change
+    add_column :authors, :github_issue_num, :integer
+    remove_column :authors, :github_issue_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_25_000000) do
+ActiveRecord::Schema.define(version: 2020_09_25_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_09_25_000000) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "github_issue_id"
   end
 
   create_table "books", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_25_000001) do
+ActiveRecord::Schema.define(version: 2020_09_26_000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_09_25_000001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "github_issue_id"
+    t.text "bio"
   end
 
   create_table "books", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_26_000000) do
+ActiveRecord::Schema.define(version: 2020_09_26_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(version: 2020_09_26_000000) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "github_issue_id"
     t.text "bio"
+    t.integer "github_issue_num"
   end
 
   create_table "books", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_113043) do
+ActiveRecord::Schema.define(version: 2020_09_25_000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,14 @@ ActiveRecord::Schema.define(version: 2020_09_24_113043) do
   create_table "publishing_houses", force: :cascade do |t|
     t.string "name"
     t.decimal "discount", precision: 5, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "settings", force: :cascade do |t|
+    t.string "name"
+    t.string "type"
+    t.string "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,4 +26,4 @@ bookd = Book.create(title: "Anathema", author: author5, publisher: author5, pric
 booke = Book.create(title: "Best Of", author: author2, publisher: pub3, price: 12.24)
 bookf = Book.create(title: "Anyway", author: author6, publisher: pub3, price: 19.99)
 
-github_update = Setting.create(name: 'github_update', type: 'iso8601', value: 0.days.ago.iso8601)
+github_update = Setting.create(name: 'github_update', value: 0.days.ago.iso8601)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,3 @@
-# db/seeds.rb
-
 pub1 = PublishingHouse.create(name: "ABC Publisher", discount: 40)
 pub2 = PublishingHouse.create(name: "Acme Publishing House", discount: 50)
 pub3 = PublishingHouse.create(name: "Foobar Corporation", discount: 55)
@@ -27,3 +25,5 @@ bookc = Book.create(title: "Lilly Reborn", author: author4, publisher: pub3, pri
 bookd = Book.create(title: "Anathema", author: author5, publisher: author5, price: 9.41)
 booke = Book.create(title: "Best Of", author: author2, publisher: pub3, price: 12.24)
 bookf = Book.create(title: "Anyway", author: author6, publisher: pub3, price: 19.99)
+
+github_update = Setting.create(name: 'github_update', type: 'iso8601', value: 0.days.ago.iso8601)


### PR DESCRIPTION
# How it works

In our rake task `authors:refresh`, we call the Github Issues API using the `github_api`.  Using the API we make calls to get list of issues and issue events, after a certain `since` timestamp.  We process the issues and events and make relevant changes in our database, and if everything completes to the end, we store the timestamp in the `Settings` table in the `github_update` entry.  This timestamp marks the point in time where every issue and event before it has been processed and added to your database, so the next call can use this timestamp as the `since` parameter to the Github Issues API.

This process is idempotent, if something fails during part of the rake task and does not reach the end, the `github_update` timestamp in our database simply does not get updated.  In this case when the rake task gets run again, some of the issues and events we processed before the failure would be processed again but they will not have duplicate effects (including create, update, delete).  Only when all the issues and events are succesfully processed then we update the `github_update` timestamp.

For each author in our database, we added the field `github_issue_num` to tracks which issue on Github the author is fetched from.  It is unique, starts at 1 for a new repo, so I picked it over Github Issue Id which is a long number.  In this situation, The Github Issues list becomes the source of truth, and entries our `Authors` are here to reflect that.

## Github issues response behavior

During development and testing of this feature, we found that the call to get issues will return ONE issue response for each of these things that happens to an issue:
- New issue is opened
- Issue is renamed (title change)
- Issue description changed (edit or add comment)
- Issue is reopened (previously closed)

This heavily influenced the way the rake task is written and is the justification for all of the actions.

## Github issue events response behavior

Similar to the call to get issues, the call to get issue events also takes a `since` timestamp.  Unfortunately, events are only returned for issue `closed` events, but not for new issues and issue description (comment) changes.  We still rely on it to prcoess `renamed` (author name change) events.

## Additional changes and details

- I made the `Bio` section not display on the author page if the author has no bio
- Github Issues API also return pull requests as issues, and they are denoted as such by having the `pull_request` field.  I simply filter the issues containing the `pull_request` field so we only look at real issues
- Since an author has one (created automatically as per requirement) or more books, when we delete an author through the rake task, we also cascade delete books associated with the author as well.  As future work we could create a `No author` author and assign the orphaned books to that dummy user, if we want to preserve the books data
- Time format: Github takes time format in `iso8601` format, e.g. `2020-09-28T07:22:29Z`.  It is why I used expressions like `0.days.ago.iso8601` in the code instead of `Time.now` because it gives time values like `2020-09-28 07:22:29.120376` which Github outright rejects

## Further Improvements

- Making use the `since` and `state: closed` params, we could process delete authors without using issue events, but that is still risky in case no event is generated or if it is not marked with the closed time from Github, since we need it to happen after our previous update timestamp
- Since issues that have been renamed also show up in list of updated issues, we could just use that instead of using the `renamed` event
- Authentication: add config to specific authenticating as Github user used in the Github API calls, right now the unauthenticated calls is rate limited to 60 requests per hour.  Here is the doc that describes it https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting
  ```
  For unauthenticated requests, the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the user making requests.
  ```
- Use webhooks! https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks.  It seems some of the events we are looking for, are generated if we use webhooks.  To use it we will need to make another POST endpoint that Github will call.  We also need to register our host address on Github.  We could put it up on Heroku or Digital Ocean and paste the public IP each time we run the app, in order to demo it.
- Write tests but we would have to move the code to actual class/controllers in the app, in order to mock/instantiate them for testing.
